### PR TITLE
ci: Add GH workflow to validate PR titles follow Conventional Commits.

### DIFF
--- a/.github/workflows/pr-title-checks.yaml
+++ b/.github/workflows/pr-title-checks.yaml
@@ -1,0 +1,30 @@
+name: "pr-title-checks"
+
+on:
+  pull_request_target:
+    # NOTE: Workflows triggered by this event give the workflow access to secrets and grant the
+    # `GITHUB_TOKEN` read/write repository access by default. So we need to ensure:
+    # - This workflow doesn't inadvertently check out, build, or execute untrusted code from the
+    #   pull request triggered by this event.
+    # - Each job has `permissions` set to only those necessary.
+    types: ["edited", "opened", "reopened"]
+    branches: ["main"]
+
+permissions: {}
+
+concurrency:
+  group: "${{github.workflow}}-${{github.ref}}"
+
+  # Cancel in-progress jobs for efficiency
+  cancel-in-progress: true
+
+jobs:
+  conventional-commits:
+    permissions:
+      # For amannn/action-semantic-pull-request
+      pull-requests: "read"
+    runs-on: "ubuntu-latest"
+    steps:
+      - uses: "amannn/action-semantic-pull-request@v5"
+        env:
+          GITHUB_TOKEN: "${{secrets.GITHUB_TOKEN}}"


### PR DESCRIPTION
<!--
Set the PR title to a meaningful commit message that:
- is in imperative form.
- follows the Conventional Commits specification (https://www.conventionalcommits.org).
  - See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:
fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

This PR adds a GitHub workflow to validate PR titles follow the Conventional Commits spec.

We're adding it to the repo template since this is one of the few workflows that will likely be used in all of our public repos.

# Checklist

- [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
- [x] This is a breaking change and it's been indicated in the PR title, OR this isn't a breaking change.
- [x] Necessary docs have been updated, OR docs don't need to be updated.

# Validation performed
<!-- Describe what tests and validation you performed on the change. -->

* Committed the change to my fork (kirkrodrigues/public-repo-template:main).
* Created a PR to my fork, triggering the workflow.
* Validated that changing the PR title triggered the workflow.
* Validated that the workflow detected invalid PR titles (e.g., starting with a capital letter, using an unknown type, etc.).

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html
