### PR TITLE
chore: Add GitHub pull-request template.

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,27 @@
+<!--
+Set the PR title to a meaningful commit message that:
+- is in imperative form.
+- follows the Conventional Commits specification (https://www.conventionalcommits.org).
+  - See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
+    types.
+
+Example:
+fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
+-->
+
+# Description
+<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->
+
+
+
+# Pull request checklist
+
+- [ ] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
+- [ ] This is a breaking change.
+- [ ] Necessary docs have been updated.
+
+# Validation performed
+<!-- Describe what tests and validation you performed on the change. -->
+
+
+[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,27 +1,37 @@
+<!-- markdownlint-disable MD012 -->
+
 <!--
 Set the PR title to a meaningful commit message that:
-- is in imperative form.
-- follows the Conventional Commits specification (https://www.conventionalcommits.org).
-  - See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
+
+* is in imperative form.
+* follows the Conventional Commits specification (https://www.conventionalcommits.org).
+  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
     types.
 
 Example:
+
 fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
 -->
 
 # Description
+
 <!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->
 
 
 
-# Pull request checklist
+# Checklist
 
-- [ ] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
-- [ ] This is a breaking change.
-- [ ] Necessary docs have been updated.
+<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->
+
+* [ ] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
+* [ ] This is a breaking change and that has been indicated in the PR title, OR this isn't a
+  breaking change.
+* [ ] Necessary docs have been updated, OR no docs need to be updated.
 
 # Validation performed
+
 <!-- Describe what tests and validation you performed on the change. -->
+
 
 
 [yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

This adds the GitHub PR template that we should use across all our repos.

Compared to our existing PR template, this has the following differences:

* It's been validated with markdownlint, which is why we have a comment disabling the rule that disallows multiple empty blank lines (since we want the template to have a blank line for where users should enter content).
  * The markdownlint config will be PRed to yscope-dev-utils.
* It has a Checklist section to ensure contributors (and reviewers) don't forget a few important things for each PR.

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->

Validated the template renders correctly through this PR.

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html